### PR TITLE
Edit hlt bugfixes

### DIFF
--- a/src/components/taskContainer/TaskContainer.js
+++ b/src/components/taskContainer/TaskContainer.js
@@ -58,6 +58,7 @@ class TaskContainer extends Component{
   }
 
   editTask(taskEdits, id) {
+    console.log('TSeditFN', taskEdits, id);
     _editTask(this, taskEdits, id);
   };
 

--- a/src/components/taskContainer/taskList.js
+++ b/src/components/taskContainer/taskList.js
@@ -21,8 +21,8 @@ const calcDaysOld = (dateAdded, currentDate) => {
 };
 
 const sortTasks = (task) => {
-  console.log(task);
-  console.log(task.dueDate);
+  // console.log(task);
+  // console.log(task.dueDate);
   let currentDate = new Date().toDateString();
   var daysOld = calcDaysOld(task.dateAdded, currentDate);
   var daysPastDue = calcDaysOld(task.dueDate, currentDate);

--- a/src/components/tasks/HigherLevelTask.js
+++ b/src/components/tasks/HigherLevelTask.js
@@ -25,10 +25,16 @@ class HigherLevelTask extends Component{
     this.handleChange = this.handleChange.bind(this);
 
   };
-
+//FIXME unselectable fields in empty task.
+// issues with toggle
+//
   editTaskHLT(taskedits) {
+
+    console.log('taskeditsHLT', taskedits);
     if (this.state.editing) {
+      console.log('editingHLT', this.state.editing);
       if (taskedits.taskTitle) {
+        console.log('hlt tasktitle from edit',taskedits.taskTitle);
         this.tempEditHolder.taskTitle = taskedits.taskTitle;
       }
       if (taskedits.taskDescription) {
@@ -38,7 +44,7 @@ class HigherLevelTask extends Component{
         this.tempEditHolder.dueDate = taskedits.dueDate;
       }
     }
-    console.log(this.tempEditHolder);
+    console.log('hlt temp',this.tempEditHolder);
   };
 
   toggleCollapse() {
@@ -55,6 +61,8 @@ class HigherLevelTask extends Component{
   forwardEdits(editsToFWD) {
     //sent up the line to tasklist then back to task container
     if (this.state.editing) { // this cuts down on the erroneous put req's when spaming the dropdown toggle, but not completely.
+      console.log('editinghLT fwdedits', this.state.editing);
+
       this.props.handleEditfn(editsToFWD, this.props.id);
     }
   }
@@ -125,7 +133,7 @@ class HigherLevelTask extends Component{
                     value={this.props.taskName}
                     className="m-0 align-self-center"
                     change={this.editTaskHLT}
-                    propName='taskName'
+                    propName='taskTitle'
                     validate={_.isString}
                     isDisabled= {!this.state.editing}/>
                 </div>
@@ -141,7 +149,7 @@ class HigherLevelTask extends Component{
                         value={this.props.description}
                         className="m-0 align-self-center"
                         change={this.editTaskHLT}
-                        propName='description'
+                        propName='taskDescription'
                         validate={_.isString}
                         isDisabled= {!this.state.editing}/>
                     </div>

--- a/src/components/tasks/HigherLevelTask.js
+++ b/src/components/tasks/HigherLevelTask.js
@@ -125,7 +125,9 @@ class HigherLevelTask extends Component{
                         maxDate={moment().add(45, 'days')}
                         withPortal
                         inline >
-                          <div style={{color: 'blue' }}>
+                          <div style={{color: 'blue', fontSize: '1.5em', textAlign: 'center' }} onClick={(e) => {
+                            this.toggleCalendar();
+                          }}>
                           <strong>Close</strong>
                           </div>
                       </DatePicker>

--- a/src/components/tasks/HigherLevelTask.js
+++ b/src/components/tasks/HigherLevelTask.js
@@ -25,16 +25,10 @@ class HigherLevelTask extends Component{
     this.handleChange = this.handleChange.bind(this);
 
   };
-//FIXME unselectable fields in empty task.
-// issues with toggle
-//investigate potential issue with touchstart and edit taskname.
-  editTaskHLT(taskedits) {
 
-    console.log('taskeditsHLT', taskedits);
+  editTaskHLT(taskedits) {
     if (this.state.editing) {
-      console.log('editingHLT', this.state.editing);
       if (taskedits.taskTitle) {
-        console.log('hlt tasktitle from edit',taskedits.taskTitle);
         this.tempEditHolder.taskTitle = taskedits.taskTitle;
       }
       if (taskedits.taskDescription) {
@@ -47,9 +41,12 @@ class HigherLevelTask extends Component{
     console.log('hlt temp',this.tempEditHolder);
   };
 
-  toggleCollapse() {
-    if (this.state.isCollapsed) {
-      this.toggleEditHLT();
+  toggleCollapse() { // toggle collapse logic is backwards
+    if (this.state.isCollapsed) { // clears edits (by no submission) and resets edit state
+      this.refs.editBtn.innerHTML = 'Edit';
+      this.setState({
+        editing: false,
+      });
     }
 
     this.setState({
@@ -60,8 +57,7 @@ class HigherLevelTask extends Component{
   //edit forwarding here
   forwardEdits(editsToFWD) {
     //sent up the line to tasklist then back to task container
-    if (this.state.editing) { // this cuts down on the erroneous put req's when spaming the dropdown toggle, but not completely.
-      console.log('editinghLT fwdedits', this.state.editing);
+    if (this.state.editing && !_.isEmpty(editsToFWD)) { // this cuts down on the erroneous put req's when spaming the dropdown toggle, but not completely.
 
       this.props.handleEditfn(editsToFWD, this.props.id);
     }
@@ -114,7 +110,7 @@ class HigherLevelTask extends Component{
                   <input type="checkbox" onClick={() => this.props.archiveCompletedTask(this.props.id)}/>
                   <span className="checkmark"></span>
                 </div>
-                <div className="col-10 my-auto" onTouchStart={this.toggleCollapse}>
+                <div className="col-10 my-auto">
                   <p className="counter" onClick={(e) => {
                     this.toggleCalendar();
                   }}>
@@ -123,12 +119,16 @@ class HigherLevelTask extends Component{
                   {
                     this.state.isOpen && (
                       <DatePicker
-                          selected={this.state.startDate}
-                          onChange={this.handleChange}
-                          minDate={moment().subtract(10, 'days')}
-                          maxDate={moment().add(45, 'days')}
-                          withPortal
-                          inline />
+                        selected={this.state.startDate}
+                        onChange={this.handleChange}
+                        minDate={moment().subtract(10, 'days')}
+                        maxDate={moment().add(45, 'days')}
+                        withPortal
+                        inline >
+                          <div style={{color: 'blue' }}>
+                          <strong>Close</strong>
+                          </div>
+                      </DatePicker>
                     )
                   }
                   {/* <p className="task-name">{this.props.taskName}</p> */}

--- a/src/components/tasks/HigherLevelTask.js
+++ b/src/components/tasks/HigherLevelTask.js
@@ -38,12 +38,13 @@ class HigherLevelTask extends Component{
         this.tempEditHolder.dueDate = taskedits.dueDate;
       }
     }
-    console.log('hlt temp',this.tempEditHolder);
+    console.log('hlt temp', this.tempEditHolder);
   };
 
   toggleCollapse() { // toggle collapse logic is backwards
     if (this.state.isCollapsed) { // clears edits (by no submission) and resets edit state
       this.refs.editBtn.innerHTML = 'Edit';
+      this.onEditChangeClass(false);
       this.setState({
         editing: false,
       });
@@ -63,11 +64,30 @@ class HigherLevelTask extends Component{
     }
   }
 
+  onEditChangeClass(bool) {
+    if (bool) {
+      this.refs.titleRef.classList.add("edit-mode-item");
+      this.refs.dateRef.classList.add("edit-mode-item");
+      this.refs.descRef.classList.add("edit-mode-item");
+      this.refs.checkRef.classList.add("disable-on-edit");
+    } else {
+      this.refs.titleRef.classList.remove("edit-mode-item");
+      this.refs.dateRef.classList.remove("edit-mode-item");
+      this.refs.descRef.classList.remove("edit-mode-item");
+      this.refs.checkRef.classList.remove("disable-on-edit");
+    }
+  }
+
+
   toggleEditHLT() {
     if (!this.state.editing) {
       this.refs.editBtn.innerHTML = 'Done';
+      //need to ad a class via refs to all editible feilds
+      this.onEditChangeClass(true);
     } else {
       this.refs.editBtn.innerHTML = 'Edit';
+      this.onEditChangeClass(false);
+
       this.forwardEdits(this.tempEditHolder);
       this.tempEditHolder = {};
     }
@@ -88,6 +108,11 @@ class HigherLevelTask extends Component{
     }
   }
 //NOTE check if date picker is workin righ in HigherLevelTasks
+// when in editing state true, need to apply css disable the checkbox and
+// enable curser on editable fields (cursor: 'pointer').
+//ref="dateRef"
+//ref="titleRef" had to make a div
+//ref="descRef"
   render () {
     if (this.props.dueDate === undefined) {
       var month = this.props.daysOld;
@@ -106,12 +131,12 @@ class HigherLevelTask extends Component{
           <div className="row">
             <div className={`col-12 col-md-10 offset-1 task-content level-${this.props.level}`}>
               <div className="row">
-                <div className="col-1 justify-content-center complete-box my-auto">
+                <div ref="checkRef" className="col-1 justify-content-center complete-box my-auto">
                   <input type="checkbox" onClick={() => this.props.archiveCompletedTask(this.props.id)}/>
                   <span className="checkmark"></span>
                 </div>
                 <div className="col-10 my-auto">
-                  <p className="counter" onClick={(e) => {
+                  <p className="counter" ref="dateRef" onClick={(e) => {
                     this.toggleCalendar();
                   }}>
                     {month} {day}
@@ -125,7 +150,7 @@ class HigherLevelTask extends Component{
                         maxDate={moment().add(45, 'days')}
                         withPortal
                         inline >
-                          <div style={{color: 'blue', fontSize: '1.5em', textAlign: 'center' }} onClick={(e) => {
+                          <div style={{color: 'blue', fontSize: '1.5em', textAlign: 'center', cursor: 'pointer' }} onClick={(e) => {
                             this.toggleCalendar();
                           }}>
                           <strong>Close</strong>
@@ -134,13 +159,15 @@ class HigherLevelTask extends Component{
                     )
                   }
                   {/* <p className="task-name">{this.props.taskName}</p> */}
-                  <RIEInput
+                  <div ref="titleRef">
+                    <RIEInput
                     value={taskTitleHLT}
                     className="m-0 align-self-center"
                     change={this.editTaskHLT}
                     propName='taskTitle'
                     validate={_.isString}
                     isDisabled= {!this.state.editing}/>
+                  </div>
                 </div>
                 <div className="col-1 d-flex right-content">
                   <div className="col-12 d-inline-flex dropdown" onClick={this.toggleCollapse}>
@@ -149,7 +176,7 @@ class HigherLevelTask extends Component{
                 </div>
                 <Collapse className="col-12" isOpen={this.state.isCollapsed} >
                   <div className="row">
-                    <div className={`col-10 offset-1 col-sm-8 offset-1 task-description edit-this-task-${this.props.taskID}`}>
+                    <div className={`col-10 offset-1 col-sm-8 offset-1 task-description edit-this-task-${this.props.taskID}`} ref="descRef">
                       <RIEInput
                         value={taskDescriptionHLT}
                         className="m-0 align-self-center"

--- a/src/components/tasks/HigherLevelTask.js
+++ b/src/components/tasks/HigherLevelTask.js
@@ -27,7 +27,7 @@ class HigherLevelTask extends Component{
   };
 //FIXME unselectable fields in empty task.
 // issues with toggle
-//
+//investigate potential issue with touchstart and edit taskname.
   editTaskHLT(taskedits) {
 
     console.log('taskeditsHLT', taskedits);
@@ -101,6 +101,9 @@ class HigherLevelTask extends Component{
       day = 'DAYS OVERDUE';
     };
 
+    let taskTitleHLT = this.props.taskName || 'title';
+    let taskDescriptionHLT = this.props.description || 'description';
+
     return (
       <div>
         <div id= { this.props.id } className="container task">
@@ -130,7 +133,7 @@ class HigherLevelTask extends Component{
                   }
                   {/* <p className="task-name">{this.props.taskName}</p> */}
                   <RIEInput
-                    value={this.props.taskName}
+                    value={taskTitleHLT}
                     className="m-0 align-self-center"
                     change={this.editTaskHLT}
                     propName='taskTitle'
@@ -146,7 +149,7 @@ class HigherLevelTask extends Component{
                   <div className="row">
                     <div className={`col-10 offset-1 col-sm-8 offset-1 task-description edit-this-task-${this.props.taskID}`}>
                       <RIEInput
-                        value={this.props.description}
+                        value={taskDescriptionHLT}
                         className="m-0 align-self-center"
                         change={this.editTaskHLT}
                         propName='taskDescription'

--- a/src/components/tasks/LowerLevelTask.js
+++ b/src/components/tasks/LowerLevelTask.js
@@ -42,8 +42,11 @@ class LowerLevelTask extends Component {
   };
 
   toggleCollapse() {
-    if (this.state.isCollapsed) {
-      this.toggleEditLLT();
+    if (this.state.isCollapsed) {// clears edits (by no submission) and resets edit state
+      this.refs.editBtn.innerHTML = 'Edit';
+      this.setState({
+        editing: false,
+      });
     }
 
     this.setState({
@@ -54,7 +57,7 @@ class LowerLevelTask extends Component {
   //edit forwarding here
   forwardEdits(editsToFWD) {
     //sent up the line to tasklist then back to task container
-    if (this.state.editing) {// this cuts down on the erroneous put req's when spaming the dropdown toggle, but not completely.
+    if (this.state.editing && !_.isEmpty(editsToFWD)) {// this cuts down on the erroneous put req's when spaming the dropdown toggle, but not completely.
       this.props.handleEditfn(editsToFWD, this.props.id);
     }
   }
@@ -74,7 +77,6 @@ class LowerLevelTask extends Component {
 
   handleChange (date) {
     this.editTaskLLT({ dueDate: date._d });
-    console.log('handle called');
     this.toggleCalendar();
   }
 
@@ -113,7 +115,7 @@ class LowerLevelTask extends Component {
                     <input type="checkbox" onClick={() => this.props.archiveCompletedTask(this.props.id)}/>
                     <span className="checkmark"></span>
                   </div>
-                  <div className="col-8 col-sm-9 d-flex" onTouchStart={this.toggleCollapse}>
+                  <div className="col-8 col-sm-9 d-flex">
                     {/* <p className="m-0 align-self-center" ref="nameP">{this.props.taskName}</p> */}
                     <RIEInput
                       value={taskTitleLLT}

--- a/src/components/tasks/LowerLevelTask.js
+++ b/src/components/tasks/LowerLevelTask.js
@@ -44,6 +44,7 @@ class LowerLevelTask extends Component {
   toggleCollapse() {
     if (this.state.isCollapsed) {// clears edits (by no submission) and resets edit state
       this.refs.editBtn.innerHTML = 'Edit';
+      this.onEditChangeClass(false);
       this.setState({
         editing: false,
       });
@@ -62,11 +63,27 @@ class LowerLevelTask extends Component {
     }
   }
 
+  onEditChangeClass(bool) {
+    if (bool) {
+      this.refs.titleRef.classList.add("edit-mode-item");
+      this.refs.dateRef.classList.add("edit-mode-item");
+      this.refs.descRef.classList.add("edit-mode-item");
+      this.refs.checkRef.classList.add("disable-on-edit");
+    } else {
+      this.refs.titleRef.classList.remove("edit-mode-item");
+      this.refs.dateRef.classList.remove("edit-mode-item");
+      this.refs.descRef.classList.remove("edit-mode-item");
+      this.refs.checkRef.classList.remove("disable-on-edit");
+    }
+  }
+
   toggleEditLLT() {
     if (!this.state.editing) {
       this.refs.editBtn.innerHTML = 'Done';
+      this.onEditChangeClass(true);
     } else {
       this.refs.editBtn.innerHTML = 'Edit';
+      this.onEditChangeClass(false);
       this.forwardEdits(this.tempEditHolder);
       this.tempEditHolder = {};
     }
@@ -81,7 +98,6 @@ class LowerLevelTask extends Component {
   }
 
   toggleCalendar (e) {
-    console.log('toggle called');
     if (this.state.editing) {
       e && e.preventDefault();
       this.setState({isOpen: !this.state.isOpen});
@@ -111,11 +127,11 @@ class LowerLevelTask extends Component {
             <div className="row">
               <div className={`col-12 col-md-10 offset-1 task-content level-${this.props.level}`}>
                 <div className="row">
-                  <div className="col-1 justify-content-center complete-box my-auto ">
+                  <div ref="checkRef" className="col-1 justify-content-center complete-box my-auto ">
                     <input type="checkbox" onClick={() => this.props.archiveCompletedTask(this.props.id)}/>
                     <span className="checkmark"></span>
                   </div>
-                  <div className="col-8 col-sm-9 d-flex">
+                  <div className="col-8 col-sm-9 d-flex" ref="titleRef">
                     {/* <p className="m-0 align-self-center" ref="nameP">{this.props.taskName}</p> */}
                     <RIEInput
                       value={taskTitleLLT}
@@ -126,7 +142,7 @@ class LowerLevelTask extends Component {
                       isDisabled= {!this.state.editing}/>
                   </div>
                   <div className="col-2 d-flex right-content">
-                    <div className="col-10 days-old-count" ref="dateDiv" onClick={(e) => {
+                    <div className="col-10 days-old-count" ref="dateRef" onClick={(e) => {
                       this.toggleCalendar();
                     }}>
                       <p className="date m-0">{month}</p>
@@ -141,7 +157,7 @@ class LowerLevelTask extends Component {
                             maxDate={moment().add(45, 'days')}
                             withPortal
                             inline >
-                              <div style={{color: 'blue', fontSize: '1.5em', textAlign: 'center' }} onClick={(e) => {
+                              <div style={{color: 'blue', fontSize: '1.5em', textAlign: 'center', cursor: 'pointer' }} onClick={(e) => {
                                 this.toggleCalendar();
                               }}>
                               <strong>Close</strong>
@@ -155,7 +171,7 @@ class LowerLevelTask extends Component {
                   </div>
                   <Collapse className="col-12" isOpen={this.state.isCollapsed} >
                     <div className="row">
-                      <div className={`col-10 offset-1 col-sm-8 offset-1 task-description edit-this-task-${this.props.taskID}`}>
+                      <div className={`col-10 offset-1 col-sm-8 offset-1 task-description edit-this-task-${this.props.taskID}`} ref="descRef">
                         {/* <p ref="descP">{this.props.description}</p> */}
                         <RIEInput
                           value={taskDescriptionLLT}

--- a/src/components/tasks/LowerLevelTask.js
+++ b/src/components/tasks/LowerLevelTask.js
@@ -140,7 +140,13 @@ class LowerLevelTask extends Component {
                             minDate={moment().subtract(10, 'days')}
                             maxDate={moment().add(45, 'days')}
                             withPortal
-                            inline />
+                            inline >
+                              <div style={{color: 'blue', fontSize: '1.5em', textAlign: 'center' }} onClick={(e) => {
+                                this.toggleCalendar();
+                              }}>
+                              <strong>Close</strong>
+                              </div>
+                          </DatePicker>
                       )
                     }
                     <div className="col-2 d-inline-flex dropdown" onClick={this.toggleCollapse}>

--- a/src/components/tasks/LowerLevelTask.js
+++ b/src/components/tasks/LowerLevelTask.js
@@ -100,6 +100,9 @@ class LowerLevelTask extends Component {
       day = dueDateArray[2];
     };
 
+    let taskTitleLLT = this.props.taskName || 'title';
+    let taskDescriptionLLT = this.props.description || 'description';
+
     return (
         <div>
           <div id={this.props.id} className="container task">
@@ -113,7 +116,7 @@ class LowerLevelTask extends Component {
                   <div className="col-8 col-sm-9 d-flex" onTouchStart={this.toggleCollapse}>
                     {/* <p className="m-0 align-self-center" ref="nameP">{this.props.taskName}</p> */}
                     <RIEInput
-                      value={this.props.taskName}
+                      value={taskTitleLLT}
                       className="m-0 align-self-center"
                       change={this.editTaskLLT}
                       propName='taskTitle'
@@ -147,7 +150,7 @@ class LowerLevelTask extends Component {
                       <div className={`col-10 offset-1 col-sm-8 offset-1 task-description edit-this-task-${this.props.taskID}`}>
                         {/* <p ref="descP">{this.props.description}</p> */}
                         <RIEInput
-                          value={this.props.description}
+                          value={taskDescriptionLLT}
                           className="m-0 align-self-center"
                           change={this.editTaskLLT}
                           propName='taskDescription'

--- a/src/components/tasks/higherlevel.css
+++ b/src/components/tasks/higherlevel.css
@@ -70,6 +70,13 @@
   padding-right:0px;
 }
 
+.edit-mode-item {
+  cursor: pointer;
+}
+.disable-on-edit {
+  pointer-events: none;
+}
+
 @media (max-width: 575px) {
   .level-5 > .row > .col-10 {
     font-size: 1.7rem;

--- a/src/components/tasks/lowerlevel.css
+++ b/src/components/tasks/lowerlevel.css
@@ -21,6 +21,13 @@
   font-size: 1.625rem;
 }
 
+.edit-mode-item {
+  cursor: pointer;
+}
+.disable-on-edit {
+  pointer-events: none;
+}
+
 @media (max-width: 575px) {
   .level-1 {
     font-size: 1rem;


### PR DESCRIPTION
Fixed unable to edit HLT. fixed req spamming when toggling edit, fixed un-closable date picker, fixed blank tasks not being editable. smoothed out toggles for edit and collapse. additionally collapsing a task now cancels edits and toggles off edit mode.